### PR TITLE
Remove no-bind

### DIFF
--- a/react.json
+++ b/react.json
@@ -69,7 +69,6 @@
     "react/jsx-filename-extension": "off",
     "react/jsx-handler-names": "off",
     "react/jsx-max-props-per-line": "off",
-    "react/jsx-no-bind": "error",
     "react/jsx-sort-props": "off",
     "react/no-children-prop": "error",
     "react/no-comment-textnodes": "off",


### PR DESCRIPTION
No need for this rule as it interferes with const functions https://stackoverflow.com/questions/36677733/why-shouldnt-jsx-props-use-arrow-functions-or-bind