### PR TITLE
Remove "react-hooks/exhaustive-deps"

### DIFF
--- a/react.json
+++ b/react.json
@@ -124,7 +124,6 @@
     "react/no-unstable-nested-components": "error",
     "react/no-namespace": "error",
     "react/prefer-exact-props": "off",
-    "react-hooks/exhaustive-deps": "error",
     "react-hooks/rules-of-hooks": "error"
   }
 }


### PR DESCRIPTION
this rule is is not needed since devs need to make sure the deps are right
![image](https://user-images.githubusercontent.com/12447231/135853765-ce7d2104-9a81-413e-a0df-0e6376ef7503.png)
Here it is warning me that i need to add touchpoints to my references and i do not want that to trigger this effect.