### PR TITLE
Turn off no-unnecessary-condition, it is too buggy

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -120,7 +120,7 @@
     "@typescript-eslint/no-throw-literal": "error",
     "@typescript-eslint/no-type-alias": "off",
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
-    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-condition": "off",
     "@typescript-eslint/no-unnecessary-qualifier": "error",
     "@typescript-eslint/no-unnecessary-type-arguments": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osskit/eslint-config",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "The eslint config used by osskit",
   "main": "eslint.json",
   "scripts": {


### PR DESCRIPTION
Partial rollback ot `1.0.12`.

`@typescript-eslint/no-unnecessary-condition` This rule is useful in theory, but in practice it's too buggy and produces many false positives.
See for example:
https://github.com/typescript-eslint/typescript-eslint/issues/1798 (and also [many other issues](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+no-unnecessary-condition))